### PR TITLE
Fix no module named views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 app.sqlite
 .cache
+*.pyc
+env
+venv


### PR DESCRIPTION
Command 'python manage.py init_db' causes exception error due to missed a `__init__.py` file under app/views directory.

Also, I did a minor update into .gitignore file.